### PR TITLE
Add webapp example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ The `dist` directory contains the bundled code that is pushed to Google Apps Scr
 
 ![Google Apps Script - Setup Development Environment](images/npm-install.gif)
 
+### Example Webapp
+
+Run `doGetExample` to serve `webapp-example.html`. It demonstrates calling a
+server function (`getGmailAliases`) from client-side code using
+`google.script.run`.
+
 ### The .claspignore file
 
 The `.claspignore` file allows you to specify file and directories that you do not wish to upload to your Google Apps Script project via `clasp push`.

--- a/ai/README.md
+++ b/ai/README.md
@@ -1,0 +1,14 @@
+# AI Cloudflare Connector
+
+This folder contains utilities for connecting to Cloudflare's API.
+
+The `cloudflare.js` module exports a `verifyCloudflareToken` function that verifies
+an API token specified in the environment variable `CLOUDFLARE_API_TOKEN`.
+
+## Usage
+
+Run the script directly with Node to test your token:
+
+```sh
+CLOUDFLARE_API_TOKEN=<your-token> node ai/cloudflare.js
+```

--- a/ai/cloudflare.js
+++ b/ai/cloudflare.js
@@ -1,0 +1,31 @@
+export async function verifyCloudflareToken() {
+  const token = process.env.CLOUDFLARE_API_TOKEN;
+  if (!token) {
+    throw new Error('CLOUDFLARE_API_TOKEN is not defined');
+  }
+
+  const response = await fetch(
+    'https://api.cloudflare.com/client/v4/user/tokens/verify',
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Cloudflare API error: ${response.status}`);
+  }
+
+  const data = await response.json();
+  console.log(data);
+  return data;
+}
+
+// Execute if this file is run directly via `node ai/cloudflare.js`
+if (import.meta.url === `file://${process.argv[1]}`) {
+  verifyCloudflareToken().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/src/html/webapp-example.html
+++ b/src/html/webapp-example.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <base target="_top">
+  <script>
+    function loadAliases() {
+      google.script.run.withSuccessHandler(function(aliases) {
+        const ul = document.getElementById('aliases');
+        aliases.forEach(function(a) {
+          var li = document.createElement('li');
+          li.textContent = a;
+          ul.appendChild(li);
+        });
+      }).getGmailAliases();
+    }
+  </script>
+</head>
+<body onload="loadAliases()">
+  <h1>Webapp Example</h1>
+  <p>The following Gmail aliases were retrieved on the server:</p>
+  <ul id="aliases"></ul>
+</body>
+</html>

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import { getGmailAliases } from './server/gmail.js';
 import { makeQueryString } from './server/http.js';
 import { doGet } from './server/webapp.js';
+import { doGetExample } from './server/webappExample.js';
 
-export { doGet, getGmailAliases, makeQueryString };
+export { doGet, doGetExample, getGmailAliases, makeQueryString };

--- a/src/server/webappExample.js
+++ b/src/server/webappExample.js
@@ -1,0 +1,7 @@
+export const doGetExample = () => {
+  const fileName = 'webapp-example.html';
+  const title = 'Webapp Example';
+  return HtmlService.createHtmlOutputFromFile(fileName)
+    .setTitle(title)
+    .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.DEFAULT);
+};


### PR DESCRIPTION
## Summary
- add `webappExample.js` server with a `doGetExample` function
- add `webapp-example.html` using google.script.run
- export `doGetExample` via `src/index.js`
- document example webapp in README

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run test` *(fails: missing script)*