### PR TITLE
Add Cloudflare Worker example

### DIFF
--- a/ai/README.md
+++ b/ai/README.md
@@ -1,0 +1,14 @@
+# AI Cloudflare Connector
+
+This folder contains utilities for connecting to Cloudflare's API.
+
+The `cloudflare.js` module exports a `verifyCloudflareToken` function that verifies
+an API token specified in the environment variable `CLOUDFLARE_API_TOKEN`.
+
+## Usage
+
+Run the script directly with Node to test your token:
+
+```sh
+CLOUDFLARE_API_TOKEN=<your-token> node ai/cloudflare.js
+```

--- a/ai/cloudflare.js
+++ b/ai/cloudflare.js
@@ -1,0 +1,31 @@
+export async function verifyCloudflareToken() {
+  const token = process.env.CLOUDFLARE_API_TOKEN;
+  if (!token) {
+    throw new Error('CLOUDFLARE_API_TOKEN is not defined');
+  }
+
+  const response = await fetch(
+    'https://api.cloudflare.com/client/v4/user/tokens/verify',
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Cloudflare API error: ${response.status}`);
+  }
+
+  const data = await response.json();
+  console.log(data);
+  return data;
+}
+
+// Execute if this file is run directly via `node ai/cloudflare.js`
+if (import.meta.url === `file://${process.argv[1]}`) {
+  verifyCloudflareToken().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/cloudflare/README.md
+++ b/cloudflare/README.md
@@ -1,0 +1,22 @@
+# Cloudflare Worker
+
+This folder contains a sample Cloudflare Worker that responds with a greeting.
+
+## Setup
+
+1. Install the [Wrangler](https://developers.cloudflare.com/workers/wrangler/) CLI:
+   ```sh
+   npm install -g wrangler
+   ```
+2. Authenticate with your Cloudflare account:
+   ```sh
+   wrangler login
+   ```
+
+## Deploy
+
+Run the following command inside this folder to deploy the worker:
+
+```sh
+wrangler deploy
+```

--- a/cloudflare/worker.js
+++ b/cloudflare/worker.js
@@ -1,0 +1,5 @@
+export default {
+  async fetch(request, env, ctx) {
+    return new Response('Hello from Cloudflare Worker!');
+  }
+};

--- a/cloudflare/wrangler.toml
+++ b/cloudflare/wrangler.toml
@@ -1,0 +1,3 @@
+name = "kitstartgas-worker"
+main = "worker.js"
+compatibility_date = "2024-05-01"


### PR DESCRIPTION
## Summary
- add `cloudflare` folder with a simple Worker script
- document setup and deployment using Wrangler

## Testing
- `npm run build` *(fails: vite not found)*
- `npm test` *(fails: missing script)*