### PR TITLE
Add Cloudflare auto deploy workflow

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -1,0 +1,23 @@
+name: Deploy Cloudflare Worker
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install Wrangler
+        run: npm install -g wrangler
+      - name: Deploy Worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          cd cloudflare
+          wrangler deploy

--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ function notTestable() {
 
 Check out [jest 'expects' here](https://jestjs.io/docs/expect)
 
+## Cloudflare WebApp deployment
+
+The repository includes a `cloudflare` folder with a Worker that serves a simple web page. A GitHub Actions workflow deploys this Worker to Cloudflare automatically whenever changes are pushed to the `main` branch. Define a `CLOUDFLARE_API_TOKEN` secret in your GitHub repository to enable the deployment.
+
+
 ## :fire: Meet the Developer
 
 <img align="left" width="100" height="100" src="https://pbs.twimg.com/profile_images/1320276905271070727/zQUrdqxO_200x200.jpg">

--- a/cloudflare/README.md
+++ b/cloudflare/README.md
@@ -1,6 +1,6 @@
 # Cloudflare Worker
 
-This folder contains a sample Cloudflare Worker that responds with a greeting.
+This folder contains a sample Cloudflare Worker that serves a simple web page.
 
 ## Setup
 
@@ -13,10 +13,14 @@ This folder contains a sample Cloudflare Worker that responds with a greeting.
    wrangler login
    ```
 
-## Deploy
+## Deploy manually
 
 Run the following command inside this folder to deploy the worker:
 
 ```sh
 wrangler deploy
 ```
+
+## Automatic deployments
+
+The repository includes a GitHub Actions workflow that automatically deploys this worker whenever changes are pushed to the `main` branch. Create a `CLOUDFLARE_API_TOKEN` secret in your GitHub repository to enable automatic deployments.

--- a/cloudflare/index.html
+++ b/cloudflare/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>kitSTARTgas Cloudflare WebApp</title>
+</head>
+<body>
+  <h1>Hello from the Cloudflare WebApp!</h1>
+  <p>This page is served by a Cloudflare Worker and deployed automatically via GitHub Actions.</p>
+</body>
+</html>

--- a/cloudflare/worker.js
+++ b/cloudflare/worker.js
@@ -1,5 +1,9 @@
+import indexHtml from './index.html';
+
 export default {
   async fetch(request, env, ctx) {
-    return new Response('Hello from Cloudflare Worker!');
+    return new Response(indexHtml, {
+      headers: { 'Content-Type': 'text/html' }
+    });
   }
 };

--- a/cloudflare/wrangler.toml
+++ b/cloudflare/wrangler.toml
@@ -1,3 +1,6 @@
 name = "kitstartgas-worker"
 main = "worker.js"
 compatibility_date = "2024-05-01"
+
+[site]
+bucket = "./"


### PR DESCRIPTION
## Summary
- add workflow for deploying Cloudflare Worker on push to `main`
- create basic HTML page for Worker
- update Worker to serve the new web page
- configure wrangler to serve the site
- document automatic Cloudflare deployments

## Testing
- `npm run build` *(fails: vite not found)*